### PR TITLE
Light-level polling

### DIFF
--- a/arduinoSmarticle/arduinoSmarticle.ino
+++ b/arduinoSmarticle/arduinoSmarticle.ino
@@ -296,6 +296,8 @@ void moveMotor(uint8_t pos){ //break method into chunks to allow "multithreading
 		oldP2=p2;
     S1.writeMicroseconds(p1=1500);
     S2.writeMicroseconds(p2=1500);
+		lightLevelDelay(1500);
+    lightLevelDelay(random(100));
 		return;
 	}
 	


### PR DESCRIPTION
Needed to add in a delay on the inactive gait state so that it would
still have a chance to read the photoresistors. If this did not happen
then the lightLevels would drop to zero and the smarticles would
immediately fall out of the inactive state.